### PR TITLE
CI Build

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,8 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <config>
-    <add key="repositorypath" value="src/packages" />
+    <add key="repositorypath" value="packages" />
   </config>
+  <packageSources>
+    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+    <add key="OpenStack.NET MyGet" value="https://www.myget.org/F/openstacknetsdk/api/v2" />
+  </packageSources>
+  <activePackageSource>
+    <add key="All" value="(Aggregate source)" />
+  </activePackageSource>
   <packageRestore>
     <add key="enabled" value="True" />
     <add key="automatic" value="True" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <activePackageSource>
-    <add key="All" value="(Aggregate source)" />
-  </activePackageSource>
-  <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
+  <config>
+    <add key="repositorypath" value="src/packages" />
+  </config>
+  <packageRestore>
+    <add key="enabled" value="True" />
+    <add key="automatic" value="True" />
+  </packageRestore>
 </configuration>

--- a/README.md
+++ b/README.md
@@ -7,3 +7,35 @@ We are in the middle of migrating Rackspace solutions out of [OpenStack.NET](htt
 * [Migration Plan and FAQ](https://github.com/openstacknetsdk/openstack.net/wiki/Rackspace-and-OpenStack.NET)
 * [OpenStack.NET 1.5.x Milestones](https://github.com/openstacknetsdk/openstack.net/milestones)
 * [Rackspace .NET SDK 0.x Milesones](https://github.com/rackspace/rackspace.net/milestones)
+
+## Building from Source
+** Prerequisites **
+* Visual Studio 2015
+
+### Build script
+
+Execute `build.cmd` to download all dependencies and build. Use `build.cmd help` or `build.cmd /?` to view the available command line arguments.
+
+```bash
+build.cmd [Build|UnitTest|Documentation|Package] [/Configuration Debug|Release]
+
+# Execute Build target in Debug mode
+build.cmd
+
+# Execute UnitTest target in Debug mode
+build.cmd UnitTest
+
+# Execute Build target in Release mode
+build.cmd /Configuration Release
+
+# Execute Package target in Release mode
+build.cmd Package /Configuration Release
+```
+
+### Integration Tests
+You must have a Rackspace cloud account to test against in order to run the integration tests. The tests look for the credentials in environment variables: RACKSPACENET_USER and RACKSPACENET_APIKEY. After you have set the environment variables you will need to log out, then log back in.
+
+```batchfile
+setx RACKSPACENET_USER secretusername
+setx RACKSPACENET_APIKEY secretpassword
+```

--- a/Rackspace.sln
+++ b/Rackspace.sln
@@ -5,6 +5,7 @@ VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{CC35C73A-4149-4585-9498-8AF3DB9CF2DF}"
 	ProjectSection(SolutionItems) = preProject
+		build\build.proj = build\build.proj
 		NuGet.config = NuGet.config
 	EndProjectSection
 EndProject
@@ -12,15 +13,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rackspace.UnitTests", "test
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rackspace", "src\Rackspace\Rackspace.csproj", "{DB3F7359-22D2-4A89-845D-1B034C84D844}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "OpenStack.NET", "OpenStack.NET", "{B2EFD65E-3A10-40C7-AF4C-DCF09315C1E3}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rackspace.IntegrationTests", "test\Rackspace.IntegrationTests\Rackspace.IntegrationTests.csproj", "{96D6144F-38B2-45CE-AEF4-9F7C23BF0EDC}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenStack", "..\openstack.net\src\corelib\OpenStack.csproj", "{1A4FB67F-8642-4402-B931-118955AE7538}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenStack.UnitTests", "..\openstack.net\src\testing\unit\OpenStack.UnitTests.csproj", "{AC3D4496-F18B-4907-9FEB-E87F9C6CB7E4}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenStack.IntegrationTests", "..\openstack.net\src\testing\integration\OpenStack.IntegrationTests.csproj", "{0C731980-8780-4F9B-9D14-DED790FD649A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -40,25 +33,8 @@ Global
 		{96D6144F-38B2-45CE-AEF4-9F7C23BF0EDC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{96D6144F-38B2-45CE-AEF4-9F7C23BF0EDC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{96D6144F-38B2-45CE-AEF4-9F7C23BF0EDC}.Release|Any CPU.Build.0 = Release|Any CPU
-		{1A4FB67F-8642-4402-B931-118955AE7538}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{1A4FB67F-8642-4402-B931-118955AE7538}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1A4FB67F-8642-4402-B931-118955AE7538}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1A4FB67F-8642-4402-B931-118955AE7538}.Release|Any CPU.Build.0 = Release|Any CPU
-		{AC3D4496-F18B-4907-9FEB-E87F9C6CB7E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{AC3D4496-F18B-4907-9FEB-E87F9C6CB7E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{AC3D4496-F18B-4907-9FEB-E87F9C6CB7E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{AC3D4496-F18B-4907-9FEB-E87F9C6CB7E4}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0C731980-8780-4F9B-9D14-DED790FD649A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0C731980-8780-4F9B-9D14-DED790FD649A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0C731980-8780-4F9B-9D14-DED790FD649A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0C731980-8780-4F9B-9D14-DED790FD649A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{1A4FB67F-8642-4402-B931-118955AE7538} = {B2EFD65E-3A10-40C7-AF4C-DCF09315C1E3}
-		{AC3D4496-F18B-4907-9FEB-E87F9C6CB7E4} = {B2EFD65E-3A10-40C7-AF4C-DCF09315C1E3}
-		{0C731980-8780-4F9B-9D14-DED790FD649A} = {B2EFD65E-3A10-40C7-AF4C-DCF09315C1E3}
 	EndGlobalSection
 EndGlobal

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,40 @@
+@echo off
+setlocal
+
+:: Parse the arguments
+IF "%1"=="/?" ( GOTO :help )
+IF "%1"=="help" ( GOTO :help )
+
+:parse
+IF NOT "%1"=="" (
+  IF /I "%1"=="/Configuration" (
+    SET ConfigArg=/p:Configuration=%2
+  ) ELSE (
+    SET TargetArg=/t:%1
+    SHIFT
+    GOTO :parse
+  )
+)
+
+:: Load the environment of the most recent version of Visual Studio installed
+if not defined VisualStudioVersion (
+    if defined VS140COMNTOOLS (
+        call "%VS140COMNTOOLS%\VsDevCmd.bat"
+        goto :build
+    )
+
+    echo Error: build.cmd requires Visual Studio 2015.
+    exit /b 1
+)
+
+:build
+msbuild build\build.proj %TargetArg% %ConfigArg% /nologo
+exit /b %ERRORLEVEL%
+
+:help
+echo build.cmd [Build^|UnitTest^|IntegrationTest^|Documentation^|Package] [/Configuration Debug^|Release]
+echo.
+echo Examples:
+echo build.cmd
+echo build.cmd UnitTest
+echo build.cmd Package /Configuration Release

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+cmd.exe //C build.cmd "$@"

--- a/build/build.proj
+++ b/build/build.proj
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <Configuration>Debug</Configuration>
+    <Version>0.1.0</Version>
+
+    <NuGet>$(LocalAppData)\NuGet\NuGet.exe</NuGet>
+    <MSBuild>&quot;$(MSBuildToolsPath)\MSBuild.exe&quot;</MSBuild>
+    <XUnit>..\packages\xunit.runner.console.2.0.0\tools\xunit.console.exe</XUnit>
+    <XUnitXslt>..\packages\xunit.runner.console.2.0.0\tools\NUnitXml.xslt</XUnitXslt>
+  </PropertyGroup>
+
+  <Target Name="CI">
+    <PropertyGroup>
+      <Configuration>Release</Configuration>
+    </PropertyGroup>
+
+    <CallTarget Targets="Build" />
+    <CallTarget Targets="UnitTest" />
+    <CallTarget Targets="IntegrationTest" />
+  </Target>
+
+  <Target Name="Build" DependsOnTargets="RestorePackages">
+    <Exec Command="$(MSBuild) ..\Rackspace.sln /p:Configuration=$(Configuration) /nologo /v:minimal" />
+  </Target>
+
+  <Target Name="RestorePackages" DependsOnTargets="DownloadNuGet">
+    <Exec Command="$(NuGet) restore ..\Rackspace.sln" WorkingDirectory="$(MSBuildThisFileDirectory)" />
+  </Target>
+
+  <Target Name="DownloadNuGet" Condition="!Exists('$(NuGet)')">
+    <MakeDir Directories="$(LocalAppData)\NuGet" />
+    <Exec Command="@powershell -NoProfile -ExecutionPolicy unrestricted -Command &quot;$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest 'https://www.nuget.org/nuget.exe' -OutFile '$(NuGet)'&quot;" />
+  </Target>
+
+  <Target Name="UnitTest" DependsOnTargets="Build">
+    <MakeDir Directories="..\artifacts\TestResults\" />
+    <Exec Command="$(XUnit) ..\test\Rackspace.UnitTests\bin\$(Configuration)\Rackspace.UnitTests.dll -xml ..\artifacts\TestResults\unit-tests.xml" ContinueOnError="true" />
+
+    <!-- Convert test results to the NUnit format for easier reporting -->
+    <XslTransformation XmlInputPaths="..\artifacts\TestResults\unit-tests.xml"  XslInputPath="$(XUnitXslt)"
+      OutputPaths="..\artifacts\TestResults\unit-tests.nunit.xml" />
+  </Target>
+
+  <Target Name="IntegrationTest" DependsOnTargets="Build">
+    <MakeDir Directories="..\artifacts\TestResults\" />
+    <Exec Command="$(XUnit) ..\test\Rackspace.IntegrationTests\bin\$(Configuration)\Rackspace.IntegrationTests.dll -xml ..\artifacts\TestResults\integration-tests.xml -notrait ci=false" ContinueOnError="true" />
+
+    <!-- Convert test results to the NUnit format for easier reporting -->
+    <XslTransformation XmlInputPaths="..\artifacts\TestResults\integration-tests.xml"  XslInputPath="$(XUnitXslt)"
+      OutputPaths="..\artifacts\TestResults\integration-tests.nunit.xml" />
+  </Target>
+
+</Project>

--- a/src/Rackspace/Rackspace.csproj
+++ b/src/Rackspace/Rackspace.csproj
@@ -48,6 +48,9 @@
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="openstacknet">
+      <HintPath>..\..\packages\openstack.net.1.5.0-beta1\lib\net45\openstacknet.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
@@ -89,12 +92,6 @@
     <Compile Include="Serialization\IdentifierConverter.cs" />
     <Compile Include="Serialization\Page.cs" />
     <Compile Include="Testing\HttpTest.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\openstack.net\src\corelib\OpenStack.csproj">
-      <Project>{1a4fb67f-8642-4402-b931-118955ae7538}</Project>
-      <Name>OpenStack</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/src/Rackspace/packages.config
+++ b/src/Rackspace/packages.config
@@ -4,4 +4,5 @@
   <package id="Flurl.Signed" version="1.0.8" targetFramework="net452" />
   <package id="Moq" version="4.2.1507.0118" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net452" />
+  <package id="openstack.net" version="1.5.0-beta1" targetFramework="net452" />
 </packages>

--- a/test/Rackspace.IntegrationTests/CloudNetworks/v2/CloudNetworkServiceTests.cs
+++ b/test/Rackspace.IntegrationTests/CloudNetworks/v2/CloudNetworkServiceTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Linq;
-using OpenStack;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/Rackspace.IntegrationTests/Rackspace.IntegrationTests.csproj
+++ b/test/Rackspace.IntegrationTests/Rackspace.IntegrationTests.csproj
@@ -50,6 +50,9 @@
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="openstacknet">
+      <HintPath>..\..\packages\openstack.net.1.5.0-beta1\lib\net45\openstacknet.dll</HintPath>
+    </Reference>
     <Reference Include="SimpleRESTServices, Version=1.3.0.0, Culture=neutral, PublicKeyToken=8965cea5c205d3a3, processorArchitecture=MSIL">
       <HintPath>..\..\packages\SimpleRESTServices.1.3.0.1\lib\net40\SimpleRESTServices.dll</HintPath>
       <Private>True</Private>
@@ -85,14 +88,6 @@
     <Compile Include="XunitTraceListener.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\openstack.net\src\corelib\OpenStack.csproj">
-      <Project>{1A4FB67F-8642-4402-B931-118955AE7538}</Project>
-      <Name>OpenStack</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\openstack.net\src\testing\integration\OpenStack.IntegrationTests.csproj">
-      <Project>{0C731980-8780-4F9B-9D14-DED790FD649A}</Project>
-      <Name>OpenStack.IntegrationTests</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\src\Rackspace\Rackspace.csproj">
       <Project>{db3f7359-22d2-4a89-845d-1b034c84d844}</Project>
       <Name>Rackspace</Name>

--- a/test/Rackspace.IntegrationTests/Rackspace.IntegrationTests.csproj
+++ b/test/Rackspace.IntegrationTests/Rackspace.IntegrationTests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="ContentDeliveryNetworks\v1\ContentDeliveryNetworkServiceTests.cs" />
     <Compile Include="Identity\v2\IdentityTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestData.cs" />
     <Compile Include="TestIdentityProvider.cs" />
     <Compile Include="XunitTraceListener.cs" />
   </ItemGroup>

--- a/test/Rackspace.IntegrationTests/TestData.cs
+++ b/test/Rackspace.IntegrationTests/TestData.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Rackspace
+{
+    public static class TestData
+    {
+        public static string GenerateName()
+        {
+            return $"ci-test-{Guid.NewGuid()}";
+        }
+    }
+}

--- a/test/Rackspace.IntegrationTests/XunitTraceListener.cs
+++ b/test/Rackspace.IntegrationTests/XunitTraceListener.cs
@@ -1,11 +1,41 @@
+﻿using System;
+using System.Diagnostics;
 using Xunit.Abstractions;
 
 namespace Rackspace
 {
-    public class XunitTraceListener : OpenStack.XunitTraceListener
+    public class XunitTraceListener : TraceListener
     {
-        public XunitTraceListener(ITestOutputHelper testLog) : base(testLog)
+        private readonly ITestOutputHelper _testLog;
+
+        public XunitTraceListener(ITestOutputHelper testLog)
         {
+            _testLog = testLog;
+        }
+
+        public override void Write(string message)
+        {
+            if (message.StartsWith(RackspaceNet.Tracing.Http.Name))
+                return;
+
+            TryLog(message);
+        }
+
+        public override void WriteLine(string message)
+        {
+            TryLog(message);
+        }
+
+        private void TryLog(string message)
+        {
+            try
+            {
+                _testLog.WriteLine(message);
+            }
+            catch (InvalidOperationException)
+            {
+                // Unable to log to xunit because it thinks no test is active...
+            }
         }
     }
 }

--- a/test/Rackspace.IntegrationTests/packages.config
+++ b/test/Rackspace.IntegrationTests/packages.config
@@ -4,6 +4,7 @@
   <package id="Flurl.Signed" version="1.0.8" targetFramework="net452" />
   <package id="Marvin.JsonPatch.Signed" version="0.7.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net452" />
+  <package id="openstack.net" version="1.5.0-beta1" targetFramework="net452" />
   <package id="SimpleRESTServices" version="1.3.0.1" targetFramework="net452" />
   <package id="xunit" version="2.0.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />

--- a/test/Rackspace.IntegrationTests/packages.config
+++ b/test/Rackspace.IntegrationTests/packages.config
@@ -11,4 +11,6 @@
   <package id="xunit.assert" version="2.0.0" targetFramework="net452" />
   <package id="xunit.core" version="2.0.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net452" />
+  <package id="xunit.runner.console" version="2.0.0" targetFramework="net452" />
+  <package id="xunit.runner.visualstudio" version="2.0.1" targetFramework="net452" />
 </packages>

--- a/test/Rackspace.UnitTests/Rackspace.UnitTests.csproj
+++ b/test/Rackspace.UnitTests/Rackspace.UnitTests.csproj
@@ -54,6 +54,9 @@
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="openstacknet">
+      <HintPath>..\..\packages\openstack.net.1.5.0-beta1\lib\net45\openstacknet.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -92,10 +95,6 @@
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>
-    <ProjectReference Include="..\..\..\openstack.net\src\corelib\OpenStack.csproj">
-      <Project>{1a4fb67f-8642-4402-b931-118955ae7538}</Project>
-      <Name>OpenStack</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\src\Rackspace\Rackspace.csproj">
       <Project>{db3f7359-22d2-4a89-845d-1b034c84d844}</Project>
       <Name>Rackspace</Name>

--- a/test/Rackspace.UnitTests/packages.config
+++ b/test/Rackspace.UnitTests/packages.config
@@ -5,6 +5,7 @@
   <package id="Marvin.JsonPatch.Signed" version="0.7.0" targetFramework="net452" />
   <package id="Moq" version="4.2.1507.118" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net452" />
+  <package id="openstack.net" version="1.5.0-beta1" targetFramework="net452" />
   <package id="SimpleRESTServices" version="1.3.0.1" targetFramework="net452" />
   <package id="xunit" version="2.0.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />

--- a/test/Rackspace.UnitTests/packages.config
+++ b/test/Rackspace.UnitTests/packages.config
@@ -12,5 +12,6 @@
   <package id="xunit.assert" version="2.0.0" targetFramework="net452" />
   <package id="xunit.core" version="2.0.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net452" />
+  <package id="xunit.runner.console" version="2.0.0" targetFramework="net452" />
   <package id="xunit.runner.visualstudio" version="2.0.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
This is pretty much a clone of the OpenStack.NET build. It adds support for build.cmd with the following targets: Build (default), UnitTests, IntegrationTests. The CI build executes all 3.

For the foreseeable future we'll need to reference a beta build of OpenStack.NET hosted on MyGet (https://www.myget.org/gallery/openstacknetsdk). When we ship releases, the Rackspace package will take a dependency on the official version on nuget.org.

Fixes #25 
