### PR TITLE
Create Rackspace Package

### DIFF
--- a/build/Rackspace.nuspec
+++ b/build/Rackspace.nuspec
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>Rackspace</id>
+    <version>0.0.0</version>
+    <title>Rackspace .NET SDK</title>
+    <authors>carolynvs</authors>
+    <licenseUrl>https://github.com/rackspace/Rackspace.NET/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://rackspace.github.io/Rackspace.NET/</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Automating all things Rackspace</description>
+    <releaseNotes>https://github.com/rackspace/Rackspace.NET/releases/v$version$</releaseNotes>
+    <copyright>2015 Rackspace, Inc.</copyright>
+    <tags>openstack rackspace rackconnect</tags>
+    <dependencies>
+      <group targetFramework="4.5">
+        <dependency id="openstack.net" version="1.5.0-beta-1" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+
+    <!-- Runtime libraries -->
+    <file src="..\src\Rackspace\bin\$Configuration$\Rackspace.dll" target="lib\net45"/>
+    <file src="..\src\Rackspace\bin\$Configuration$\Rackspace.pdb" target="lib\net45"/>
+    <file src="..\artifacts\docs\api\Rackspace.xml" target="lib\net45"/>
+
+  </files>
+</package>

--- a/build/build.proj
+++ b/build/build.proj
@@ -3,8 +3,9 @@
 
   <PropertyGroup>
     <Configuration>Debug</Configuration>
-    <Version>0.1.0</Version>
+    <Version>0.1.0-beta1</Version>
 
+    <NuGet>$(LocalAppData)\NuGet\NuGet.exe</NuGet>
     <Paket>..\.paket\paket.exe</Paket>
     <MSBuild>&quot;$(MSBuildToolsPath)\MSBuild.exe&quot;</MSBuild>
     <XUnit>..\packages\xunit.runner.console\tools\xunit.console.exe</XUnit>
@@ -20,6 +21,7 @@
     <CallTarget Targets="UnitTest" />
     <CallTarget Targets="IntegrationTest" />
     <CallTarget Targets="Documentation" />
+    <CallTarget Targets="Package" />
   </Target>
 
   <Target Name="Build" DependsOnTargets="RestorePackages">
@@ -42,6 +44,11 @@
     <Exec Command="..\.paket\paket.bootstrapper.exe" />
   </Target>
 
+  <Target Name="DownloadNuGet" Condition="!Exists('$(NuGet)')">
+    <MakeDir Directories="$(LocalAppData)\NuGet" />
+    <Exec Command="@powershell -NoProfile -ExecutionPolicy unrestricted -Command &quot;$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest 'https://www.nuget.org/nuget.exe' -OutFile '$(NuGet)'&quot;" />
+  </Target>
+
   <Target Name="UnitTest" DependsOnTargets="Build">
     <MakeDir Directories="..\artifacts\TestResults\" />
     <Exec Command="$(XUnit) ..\test\Rackspace.UnitTests\bin\$(Configuration)\Rackspace.UnitTests.dll -xml ..\artifacts\TestResults\unit-tests.xml" ContinueOnError="true" />
@@ -60,4 +67,14 @@
       OutputPaths="..\artifacts\TestResults\integration-tests.nunit.xml" />
   </Target>
 
+  <Target Name="Package" DependsOnTargets="DownloadNuGet;Build;Documentation">
+    <MakeDir Directories="..\artifacts\packages\" />
+    <Exec Command="$(NuGet) pack Rackspace.nuspec -OutputDirectory ..\artifacts\packages -Prop Configuration=$(Configuration) -Version $(Version) -Symbols"
+          WorkingDirectory="$(MSBuildThisFileDirectory)"/>
+  </Target>
+
+  <Target Name="Publish" DependsOnTargets="DownloadNuGet">
+    <!-- The environment variable BAMBOO_NUGET_PASSWORD comes from the nuget.password variable defined on the rackspace.net plan in Bamboo -->
+    <Exec Command="$(NuGet) push ..\artifacts\packages\Rackspace.$(Version).nupkg %25BAMBOO_NUGET_PASSWORD%25" />
+  </Target>
 </Project>


### PR DESCRIPTION
Note that when we are in active development, both OpenStack.NET and Rackspace will have a -beta suffix as required by NuGet. When we release and bump versions, that suffix is removed from the build.proj files and the nuspec dependency section.
