### PR TITLE
Improve RackspaceNet Configuration

### DIFF
--- a/src/Rackspace/CloudNetworks/v2/CloudNetworkService.cs
+++ b/src/Rackspace/CloudNetworks/v2/CloudNetworkService.cs
@@ -24,6 +24,7 @@ namespace Rackspace.CloudNetworks.v2
         /// <param name="region">The region.</param>
         public CloudNetworkService(OpenStack.Authentication.IAuthenticationProvider authenticationProvider, string region)
         {
+            RackspaceNet.Configure();
             _networkingApiBuilder = new NetworkingApiBuilder(ServiceType.CloudNetworks, authenticationProvider, region);
         }
 

--- a/src/Rackspace/RackConnect/v3/RackConnectService.cs
+++ b/src/Rackspace/RackConnect/v3/RackConnectService.cs
@@ -37,6 +37,8 @@ namespace Rackspace.RackConnect.v3
             if (string.IsNullOrEmpty(region))
                 throw new ArgumentException("region cannot be null or empty", "region");
 
+            RackspaceNet.Configure();
+
             _authenticationProvider = authenticationProvider;
             _urlBuilder = new ServiceUrlBuilder(ServiceType.RackConnect, authenticationProvider, region);
         }

--- a/src/Rackspace/RackspaceNet.cs
+++ b/src/Rackspace/RackspaceNet.cs
@@ -38,14 +38,12 @@ namespace Rackspace
             {
                 if (_isConfigured)
                     return;
+                
+                OpenStackNet.Configure(configureFlurl, configureJson);
 
                 configure?.Invoke(Configuration);
+                Configuration.Apply(OpenStackNet.Configuration);
 
-                Action<OpenStackNetConfigurationOptions> configureOpenStackNet = options =>
-                {
-                    Configuration.Apply(options);
-                };
-                OpenStackNet.Configure(configureFlurl, configureJson, configureOpenStackNet);
                 _isConfigured = true;
             }
         }

--- a/test/Rackspace.UnitTests/CloudNetworks/v2/CloudNetworkServiceTests.cs
+++ b/test/Rackspace.UnitTests/CloudNetworks/v2/CloudNetworkServiceTests.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Flurl.Http;
+using Xunit;
+
+namespace Rackspace.CloudNetworks.v2
+{
+    public class CloudNetworkServiceTests : IDisposable
+    {
+        public CloudNetworkServiceTests()
+        {
+            RackspaceNet.ResetDefaults();
+        }
+
+        public void Dispose()
+        {
+            RackspaceNet.ResetDefaults();
+        }
+
+        [Fact]
+        public void RackspaceNetIsConfiguredByService()
+        {
+            Assert.Null(FlurlHttp.Configuration.BeforeCall);
+            new CloudNetworkService(Stubs.IdentityService, "region");
+            Assert.NotNull(FlurlHttp.Configuration.BeforeCall);
+        }
+    }
+}

--- a/test/Rackspace.UnitTests/RackConnect/v3/RackConnectServiceTests.cs
+++ b/test/Rackspace.UnitTests/RackConnect/v3/RackConnectServiceTests.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Flurl.Http;
+using Xunit;
+
+namespace Rackspace.RackConnect.v3
+{
+    public class RackConnectServiceTests : IDisposable
+    {
+        public RackConnectServiceTests()
+        { 
+            RackspaceNet.ResetDefaults();
+        }
+
+        public void Dispose()
+        {
+            RackspaceNet.ResetDefaults();
+        }
+
+        [Fact]
+        public void RackspaceNetIsConfiguredByService()
+        {
+            Assert.Null(FlurlHttp.Configuration.BeforeCall);
+            new RackConnectService(Stubs.IdentityService, "region");
+            Assert.NotNull(FlurlHttp.Configuration.BeforeCall);
+        }
+    }
+}

--- a/test/Rackspace.UnitTests/Rackspace.UnitTests.csproj
+++ b/test/Rackspace.UnitTests/Rackspace.UnitTests.csproj
@@ -79,11 +79,13 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CloudNetworks\v2\CloudNetworkServiceTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="CloudNetworks\v2\NetworkTests.cs" />
     <Compile Include="CloudNetworks\v2\PortTests.cs" />
     <Compile Include="CloudNetworks\v2\SubnetTests.cs" />
     <Compile Include="IdentifierTests.cs" />
+    <Compile Include="RackConnect\v3\RackConnectServiceTests.cs" />
     <Compile Include="RackConnect\v3\NetworkTests.cs" />
     <Compile Include="RackConnect\v3\PublicIPTests.cs" />
     <Compile Include="RackspaceNetTests.cs" />

--- a/test/Rackspace.UnitTests/RackspaceNetTests.cs
+++ b/test/Rackspace.UnitTests/RackspaceNetTests.cs
@@ -8,9 +8,23 @@ namespace Rackspace
 {
     public class RackspaceNetTests : IDisposable
     {
+        public RackspaceNetTests()
+        {
+            RackspaceNet.ResetDefaults();
+        }
+
         public void Dispose()
         {
-            RackspaceNet.Configuration.ResetDefaults();
+            RackspaceNet.ResetDefaults();
+        }
+
+        [Fact]
+        public void ResetDefaults_ResetsFlurlConfiguration()
+        {
+            RackspaceNet.Configure();
+            Assert.NotNull(FlurlHttp.Configuration.BeforeCall);
+            RackspaceNet.ResetDefaults();
+            Assert.Null(FlurlHttp.Configuration.BeforeCall);
         }
 
         [Fact]

--- a/test/Rackspace.UnitTests/RackspaceNetTests.cs
+++ b/test/Rackspace.UnitTests/RackspaceNetTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http.Headers;
+using System.Text.RegularExpressions;
 using Flurl.Http;
 using Rackspace.Testing;
 using Xunit;
@@ -39,6 +40,22 @@ namespace Rackspace
                 var userAgent = httpTest.CallLog[0].Request.Headers.UserAgent.ToString();
                 Assert.Contains("rackspace.net", userAgent);
                 Assert.Contains("openstack.net", userAgent);
+            }
+        }
+
+        [Fact]
+        public async void UserAgentOnlyListedOnceTest()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                RackspaceNet.Configure();
+                RackspaceNet.Configure();
+
+                await "http://api.com".GetAsync();
+
+                var userAgent = httpTest.CallLog[0].Request.Headers.UserAgent.ToString();
+                var matches = new Regex("rackspace").Matches(userAgent);
+                Assert.Equal(1, matches.Count);
             }
         }
 

--- a/test/Rackspace.UnitTests/RackspaceNetTests.cs
+++ b/test/Rackspace.UnitTests/RackspaceNetTests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Net.Http.Headers;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Flurl.Http;
+using OpenStack;
 using Rackspace.Testing;
 using Xunit;
 
@@ -20,6 +22,46 @@ namespace Rackspace
         }
 
         [Fact]
+        public async Task UseBothOpenStackAndRackspace_OpenStackConfiguredFirst()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                OpenStackNet.Configure();
+                RackspaceNet.Configure();
+
+                await "http://api.com".GetAsync();
+
+                var userAgent = httpTest.CallLog[0].Request.Headers.UserAgent.ToString();
+
+                var rackspaceMatches = new Regex("rackspace").Matches(userAgent);
+                Assert.Equal(1, rackspaceMatches.Count);
+
+                var openstackMatches = new Regex("openstack").Matches(userAgent);
+                Assert.Equal(1, openstackMatches.Count);
+            }
+        }
+
+        [Fact]
+        public async Task UseBothOpenStackAndRackspace_RackspaceConfiguredFirst()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                RackspaceNet.Configure();
+                OpenStackNet.Configure();
+
+                await "http://api.com".GetAsync();
+
+                var userAgent = httpTest.CallLog[0].Request.Headers.UserAgent.ToString();
+
+                var rackspaceMatches = new Regex("rackspace").Matches(userAgent);
+                Assert.Equal(1, rackspaceMatches.Count);
+
+                var openstackMatches = new Regex("openstack").Matches(userAgent);
+                Assert.Equal(1, openstackMatches.Count);
+            }
+        }
+
+        [Fact]
         public void ResetDefaults_ResetsFlurlConfiguration()
         {
             RackspaceNet.Configure();
@@ -29,7 +71,7 @@ namespace Rackspace
         }
 
         [Fact]
-        public async void UserAgentTest()
+        public async Task UserAgentTest()
         {
             using (var httpTest = new HttpTest())
             {
@@ -44,7 +86,7 @@ namespace Rackspace
         }
 
         [Fact]
-        public async void UserAgentOnlyListedOnceTest()
+        public async Task UserAgentOnlyListedOnceTest()
         {
             using (var httpTest = new HttpTest())
             {
@@ -54,13 +96,17 @@ namespace Rackspace
                 await "http://api.com".GetAsync();
 
                 var userAgent = httpTest.CallLog[0].Request.Headers.UserAgent.ToString();
-                var matches = new Regex("rackspace").Matches(userAgent);
-                Assert.Equal(1, matches.Count);
+
+                var rackspaceMatches = new Regex("rackspace").Matches(userAgent);
+                Assert.Equal(1, rackspaceMatches.Count);
+
+                var openstackMatches = new Regex("openstack").Matches(userAgent);
+                Assert.Equal(1, openstackMatches.Count);
             }
         }
 
         [Fact]
-        public async void UserAgentWithApplicationSuffixTest()
+        public async Task UserAgentWithApplicationSuffixTest()
         {
             using (var httpTest = new HttpTest())
             {


### PR DESCRIPTION
This fixes #40 and relies upon changes in OpenStack.NET as well.
- The `Configure` methods can now only be called once. This was necessary because we call the existing Flurl handlers in ours as well, so multiple `Configure` calls resulted in duplicate User Agent headers, log messages, etc.
- If the application needs to redo the configuration, `ResetDefaults` should be called, then `Configure`. `ResetDefaults` applies the default configuration to Flurl and Json.NET. This is mostly applicable in unit tests.
- `Configure` now works when OpenStack.NET is used side-by-side with Rackspace.NET. Their `Configure` methods can be called multiple times, in any order.
- `Configure` is called automatically by each Rackspace service constructor. This ensures that we are initialized before any requests are made. Once we hit v1.0 and we have a single common entry point (identity) this will be moved there.
