### PR TITLE
Removing sdk-support email

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,7 +1,6 @@
 This isn't an ivory tower and we would love all the help we can get! 
 
-**Please don't be shy**. If you are having problems or just have a question, open an issue or email us at 
-sdk-support@rackspace.com. Error messages and stack traces would be most helpful. :smile:
+**Please don't be shy**. If you are having problems or just have a question, pkease open an issue. Error messages and stack traces would be most helpful. :smile:
 
 Pull requests are welcome and encouraged, even if you don't have everything figured out. We can 
 chat and come up with the best way to get it finished. Direct your pull requests to the `develop` branch. 


### PR DESCRIPTION
since it's not monitored.
closes issue #46 